### PR TITLE
fix: Remove reference to non-existent animation-fix.js file

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=()">
     <link rel="stylesheet" href="css/styles.css">
-    <script src="animation-fix.js"></script>
 </head>
 <body>
     <canvas id="canvas"></canvas>


### PR DESCRIPTION
The black screen issue was caused by a script tag referencing animation-fix.js which doesn't exist in the repository. This caused a 404 error that prevented the page from loading properly.

Removed the script tag from index.html (line 16) to fix the issue.